### PR TITLE
fix: correct MiniMax provider config and add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,26 @@ For a local Ollama setup, point each role to your Ollama server:
    }
 ```
 
+For a MiniMax setup (text‑only — ideal for memory and planner roles):
+```json
+"memory_llm": {
+      "provider": "minimax",
+      "model_name": "MiniMax-M2.5",
+      "api_key": "YOUR_MINIMAX_API_KEY"
+   },
+"planner_llm": {
+      "provider": "minimax",
+      "model_name": "MiniMax-M2.5",
+      "api_key": "YOUR_MINIMAX_API_KEY"
+   }
+```
+
+Available MiniMax models: `MiniMax-M2.5` (default) and `MiniMax-M2.5-highspeed` (faster).
+Set `MINIMAX_API_KEY` env var or pass `api_key` in config.
+MiniMax uses the OpenAI‑compatible endpoint at `https://api.minimax.io/v1` (overseas) or `https://api.minimaxi.com/v1` (China mainland).
+
+> **Note:** MiniMax models are text‑only and do not support vision. Use them for `memory_llm` / `planner_llm`. For `brain_llm` / `actor_llm`, use a vision‑capable model (TuriX, Gemini, etc.).
+
 #### 4.3 Configure Custom Models (Optional)
 
 If you want to use other models not defined by the build_llm function in the main.py, you need to first define it, then setup the config.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -277,6 +277,26 @@ osascript -e 'tell application "Safari" to do JavaScript "alert("Triggering acce
    }
 ```
 
+如果要使用 MiniMax（纯文本模型，适用于 memory 和 planner 角色）：
+```json
+"memory_llm": {
+      "provider": "minimax",
+      "model_name": "MiniMax-M2.5",
+      "api_key": "YOUR_MINIMAX_API_KEY"
+   },
+"planner_llm": {
+      "provider": "minimax",
+      "model_name": "MiniMax-M2.5",
+      "api_key": "YOUR_MINIMAX_API_KEY"
+   }
+```
+
+可用的 MiniMax 模型：`MiniMax-M2.5`（默认）和 `MiniMax-M2.5-highspeed`（更快速）。
+通过环境变量 `MINIMAX_API_KEY` 或在配置中传入 `api_key`。
+MiniMax 使用 OpenAI 兼容接口，海外端点为 `https://api.minimax.io/v1`，国内端点为 `https://api.minimaxi.com/v1`。
+
+> **注意：** MiniMax 模型仅支持文本，不支持视觉功能。请将其用于 `memory_llm` / `planner_llm`。`brain_llm` / `actor_llm` 需要使用支持视觉的模型（如 TuriX、Gemini 等）。
+
 #### 4.3 配置自定义模型（可选）
 
 如果你想使用 build_llm 函数中未定义的其他模型，需要先在代码中定义，再在配置中设置。

--- a/examples/main.py
+++ b/examples/main.py
@@ -221,12 +221,13 @@ def build_llm(cfg: dict, *, enable_thinking: bool | None = None):
         )
 
     if provider == "minimax":
+        minimax_api_key = api_key or os.getenv("MINIMAX_API_KEY")
         return build_openai_compatible_llm(
-            model_name=model_name,
-            api_key=api_key,
-            base_url=base_url or "https://api.minimax.chat/v1",
-            temperature=0.1,
-            supports_tool_calling=False,
+            model_name=model_name or "MiniMax-M2.5",
+            api_key=minimax_api_key,
+            base_url=base_url or "https://api.minimax.io/v1",
+            temperature=1.0,
+            supports_tool_calling=True,
             supports_response_format=False,
             model_kwargs=model_kwargs,
             max_tokens=max_tokens,

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -1,0 +1,102 @@
+"""Unit tests for the MiniMax provider in build_llm."""
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+
+# Add project root to path
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(project_root / "examples"))
+
+# Mock out heavy dependencies before importing main
+sys.modules["pynput"] = MagicMock()
+sys.modules["pynput.keyboard"] = MagicMock()
+sys.modules["pyautogui"] = MagicMock()
+sys.modules["src"] = MagicMock()
+sys.modules["src.controller"] = MagicMock()
+sys.modules["src.controller.service"] = MagicMock()
+
+from main import build_llm
+
+
+class TestMiniMaxProvider(unittest.TestCase):
+    """Test MiniMax provider configuration in build_llm."""
+
+    @patch("main.ChatOpenAI")
+    def test_default_base_url(self, mock_chat):
+        """MiniMax should use https://api.minimax.io/v1 by default."""
+        mock_chat.return_value = MagicMock()
+        build_llm({"provider": "minimax", "api_key": "test-key"})
+        call_kwargs = mock_chat.call_args[1]
+        self.assertEqual(call_kwargs["openai_api_base"], "https://api.minimax.io/v1")
+
+    @patch("main.ChatOpenAI")
+    def test_custom_base_url(self, mock_chat):
+        """Custom base_url should override the default."""
+        mock_chat.return_value = MagicMock()
+        build_llm({
+            "provider": "minimax",
+            "api_key": "test-key",
+            "base_url": "https://api.minimaxi.com/v1",
+        })
+        call_kwargs = mock_chat.call_args[1]
+        self.assertEqual(call_kwargs["openai_api_base"], "https://api.minimaxi.com/v1")
+
+    @patch("main.ChatOpenAI")
+    def test_default_model_name(self, mock_chat):
+        """Default model should be MiniMax-M2.5."""
+        mock_chat.return_value = MagicMock()
+        build_llm({"provider": "minimax", "api_key": "test-key"})
+        call_kwargs = mock_chat.call_args[1]
+        self.assertEqual(call_kwargs["model"], "MiniMax-M2.5")
+
+    @patch("main.ChatOpenAI")
+    def test_custom_model_name(self, mock_chat):
+        """Custom model_name should be used."""
+        mock_chat.return_value = MagicMock()
+        build_llm({
+            "provider": "minimax",
+            "api_key": "test-key",
+            "model_name": "MiniMax-M2.5-highspeed",
+        })
+        call_kwargs = mock_chat.call_args[1]
+        self.assertEqual(call_kwargs["model"], "MiniMax-M2.5-highspeed")
+
+    @patch("main.ChatOpenAI")
+    def test_temperature_is_one(self, mock_chat):
+        """MiniMax temperature should be 1.0."""
+        mock_chat.return_value = MagicMock()
+        build_llm({"provider": "minimax", "api_key": "test-key"})
+        call_kwargs = mock_chat.call_args[1]
+        self.assertEqual(call_kwargs["temperature"], 1.0)
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "env-key"}, clear=False)
+    @patch("main.ChatOpenAI")
+    def test_env_api_key(self, mock_chat):
+        """MINIMAX_API_KEY env var should be used when no api_key in config."""
+        mock_chat.return_value = MagicMock()
+        build_llm({"provider": "minimax"})
+        call_kwargs = mock_chat.call_args[1]
+        self.assertEqual(call_kwargs["openai_api_key"], "env-key")
+
+    @patch("main.ChatOpenAI")
+    def test_tool_calling_enabled(self, mock_chat):
+        """MiniMax should have tool calling enabled."""
+        mock_instance = MagicMock()
+        mock_chat.return_value = mock_instance
+        result = build_llm({"provider": "minimax", "api_key": "test-key"})
+        self.assertTrue(getattr(result, "_turix_supports_tool_calling", False))
+
+    @patch("main.ChatOpenAI")
+    def test_response_format_disabled(self, mock_chat):
+        """MiniMax should have response_format disabled."""
+        mock_instance = MagicMock()
+        mock_chat.return_value = mock_instance
+        result = build_llm({"provider": "minimax", "api_key": "test-key"})
+        self.assertFalse(getattr(result, "_turix_supports_response_format", True))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR fixes and improves the existing MiniMax provider configuration in `build_llm()`:

- **Fix base URL**: Changed from `api.minimax.chat` to `api.minimax.io` (correct overseas endpoint)
- **Fix temperature**: Changed from `0.1` to `1.0` (MiniMax requires temperature in (0, 1] range)
- **Add `MINIMAX_API_KEY` env var fallback**: Consistent with other providers' env var patterns
- **Set default model**: `MiniMax-M2.5` when no `model_name` is specified
- **Enable tool calling**: MiniMax M2.5 supports function calling

## Documentation

Added MiniMax configuration sections to both `README.md` and `README.zh-CN.md`:
- Configuration examples for `memory_llm` and `planner_llm` roles
- Available models: `MiniMax-M2.5` (default), `MiniMax-M2.5-highspeed`
- API endpoints for overseas (`api.minimax.io`) and China mainland (`api.minimaxi.com`)
- Note that MiniMax is text-only and should be used for memory/planner roles (not brain/actor which require vision)

## Tests

Added `tests/test_minimax_provider.py` with 8 unit tests covering:
- Default and custom base URL
- Default and custom model name
- Temperature is 1.0
- `MINIMAX_API_KEY` env var fallback
- Tool calling enabled
- Response format disabled

All tests pass.

## Test plan

- [x] Unit tests pass (`python3 tests/test_minimax_provider.py -v`)
- [x] E2E integration test with real MiniMax API key succeeds
- [x] No changes to existing provider behavior