### PR TITLE
docs: reference ClawBench for complementary evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ TuriX scores **64.2% (229.88 / 358)** on the full OSWorld benchmark, ranking **3
 
 For more details, check our [report](https://turix.ai/technical-report/).
 
+For complementary live-web browser-agent evaluation, see [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench); this is an external benchmark reference and does not imply integration with or support from TuriX.
+
 ## 🚀 Quick‑Start (macOS 15+)
 
 > **We never collect data**—install, grant permissions, and hack away.


### PR DESCRIPTION
This README-only change adds a neutral pointer to ClawBench as a complementary live-web browser-agent benchmark near the performance section. It explicitly states that the reference does not imply TuriX integration or support.

Submitted by reacher-z (mtrxcop@gmail.com), with Codex assistance; no coauthor.